### PR TITLE
Fix wrong method name

### DIFF
--- a/post/web-platform-api/web-storage-api/index.md
+++ b/post/web-platform-api/web-storage-api/index.md
@@ -84,7 +84,7 @@ localStorage.setItem('test', { test: 1 }) //stored as "[object Object]"
 
 ```js
 localStorage.getItem('username') // 'flaviocopes'
-localStorage.setItem('id') // '123'
+localStorage.getItem('id') // '123'
 ```
 
 ### `removeItem(key)`


### PR DESCRIPTION
In the getItem() paragraph, setItem(key) was called instead of getItem(key).