### PR TITLE
fixed typo and parsing issue

### DIFF
--- a/post/web-platform-api/requestanimationframe/index.md
+++ b/post/web-platform-api/requestanimationframe/index.md
@@ -63,7 +63,7 @@ Check this example on Glitch of an [animation built using of setTimeout()](https
 <div class="glitch-embed-wrap" style="height: 681px; width: 100%;">
   <iframe src="https://glitch.com/embed/#!/embed/flavio-settimeout-animation?path=script.js&previewFirst=true" alt="flavio-settimeout-animation on glitch" style="height: 100%; width: 100%; border: 0;"></iframe>
 </div>
-<br>
+
 `requestAnimationFrame` is the standard way to perform animations, and it works in a very different way event though the code looks very similar to the setTimeout/setInterval code:
 
 ```js
@@ -111,7 +111,7 @@ If you used a higher frequency call for your animation function:
 
 ![Too frequent timeline](timeline-too-frequent.png)
 
-Notice how in each frame we call 4 animation steps, before any rendering happens, an this will make the animation feel very choppy.
+Notice how in each frame we call 4 animation steps, before any rendering happens, and this will make the animation feel very choppy.
 
 What if setTimeout cannot run on time due to other code blocking the event loop? We end up with a missed frame:
 


### PR DESCRIPTION
typo in line 114. 
line 67 was not being parsed properly because of a <br> in line 66. Not really sure if it was the <br> tag but removing it seemed to work. 
In the webpage the code block of line 69-81 is not being displayed properly but it displays properly in the preview. not sure why.