### PR TITLE
Fix typo in code example

### DIFF
--- a/post/react/react-reach-router/index.md
+++ b/post/react/react-reach-router/index.md
@@ -76,7 +76,7 @@ navigate('/private-area')
 Use the `Link` component to link to your routes using JSX:
 
 ```js
-import { navigate } from '@reach/router'
+import { Link } from '@reach/router'
 ```
 
 ```jsx


### PR DESCRIPTION
changed { navigate } to { Link } in the **Link to routes in JSX** example section