### PR TITLE
Fixed typo

### DIFF
--- a/post/web-platform-api/drag-and-drop/index.md
+++ b/post/web-platform-api/drag-and-drop/index.md
@@ -52,7 +52,7 @@ On the drop target:
 
 ## Overview of a drag and drop operation and the events fired
 
-When the user starts dragging a *draggable element*, clicking on it with the mouse and moving the mourse, or also tapping and keeping the tap and then moving the selection, the `dragstart` event is fired on it:
+When the user starts dragging a *draggable element*, clicking on it with the mouse and moving the mouse, or also tapping and keeping the tap and then moving the selection, the `dragstart` event is fired on it:
 
 ```js
 element.addEventListener('dragstart', event => {


### PR DESCRIPTION
There was a typo in the spelling of "mouse."