### PR TITLE
Missing a space... ES2019 Example

### DIFF
--- a/post/javascript/es2019/index.md
+++ b/post/javascript/es2019/index.md
@@ -124,7 +124,7 @@ Return a new string with removed white space from the start of the original stri
 'Testing'.trimStart() //'Testing'
 ' Testing'.trimStart() //'Testing'
 ' Testing '.trimStart() //'Testing '
-'Testing'.trimStart() //'Testing'
+'Testing '.trimStart() //'Testing'
 ```
 
 ### `trimEnd()`


### PR DESCRIPTION
On the last example of trimStart, I noticed it was the same as the first. After checking trimEnd, I realized you meant to put a space at the end of the string 'Testing '.