### PR TITLE
Correct Minor Typo

### DIFF
--- a/post/node/node-input-from-cli/index.md
+++ b/post/node/node-input-from-cli/index.md
@@ -31,7 +31,7 @@ In this callback function, we close the readline interface.
 
 `readline` offers several other methods, and I'll let you check them out on the package documentation I linked above.
 
-If you need to require a password, it's best to now echo it back, but instead showing a `*` symbol.
+If you need to require a password, it's best to not echo it back, but instead showing a `*` symbol.
 
 The simplest way is to use the [`readline-sync` package](https://www.npmjs.com/package/readline-sync) which is very similar in terms of the API and handles this out of the box.
 


### PR DESCRIPTION
Line 34: Changed "now" to "not" in the phrase "it's best to now echo it back, but instead ..."