### PR TITLE
use correct syntax for inline script tag

### DIFF
--- a/post/pug/index.md
+++ b/post/pug/index.md
@@ -174,7 +174,7 @@ html
 ```pug
 script alert('test')
 
-script
+script.
   (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
   function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
   e=o.createElement(i);r=o.getElementsByTagName(i)[0];


### PR DESCRIPTION
Inline script tags render without errors  if the `script` tag has a period `.`